### PR TITLE
Configurable export context

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,29 @@
 PATH
   remote: .
   specs:
-    datafoodconsortium-connector (1.0.0.pre.alpha.4)
-      virtual_assembly-semantizer (~> 1.0, >= 1.0.2)
+    datafoodconsortium-connector (1.0.0.pre.alpha.8)
+      virtual_assembly-semantizer (~> 1.0, >= 1.0.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
     htmlentities (4.3.4)
-    json-canonicalization (0.3.1)
-    json-ld (3.2.3)
+    json-canonicalization (0.3.2)
+    json-ld (3.2.5)
       htmlentities (~> 4.3)
-      json-canonicalization (~> 0.3)
+      json-canonicalization (~> 0.3, >= 0.3.2)
       link_header (~> 0.0, >= 0.0.8)
       multi_json (~> 1.15)
-      rack (~> 2.2)
-      rdf (~> 3.2, >= 3.2.9)
+      rack (>= 2.2, < 4)
+      rdf (~> 3.2, >= 3.2.10)
     link_header (0.0.8)
     minitest (5.17.0)
     multi_json (1.15.0)
-    rack (2.2.6.2)
+    rack (3.0.8)
     rake (13.0.6)
-    rdf (3.2.9)
+    rdf (3.2.11)
       link_header (~> 0.0, >= 0.0.8)
-    virtual_assembly-semantizer (1.0.2)
+    virtual_assembly-semantizer (1.0.5)
       json-ld (~> 3.2, >= 3.2.3)
 
 PLATFORMS

--- a/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -33,15 +33,12 @@ class DataFoodConsortium::Connector::JsonLdSerializer
     def process(*subjects)
         return "" if subjects.empty?
 
-        inputs = []
-        
         # Insert an input context on each subject so the properties could be prefixed. This way,
         # the DFC's context can be used.
         # See https://github.com/datafoodconsortium/connector-ruby/issues/11.
-        subjects.each do |subject|
-            input = { "@context" => @outputContext }
-            input.merge!(subject.serialize(@hashSerializer))
-            inputs.push(input)
+        inputs = subjects.map do |subject|
+          # JSON::LD needs a context on every input using prefixes.
+          subject.serialize(@hashSerializer).merge("@context" => @outputContext)
         end
 
         jsonLd = JSON::LD::API.compact(inputs, @outputContext)

--- a/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -30,12 +30,8 @@ class DataFoodConsortium::Connector::JsonLdSerializer
         @hashSerializer = VirtualAssembly::Semantizer::HashSerializer.new(inputContext)
     end
 
-    def process(subject, *subjects)
-        subjects.insert(0, subject)
-
-        if (subjects.empty?)
-            return ""
-        end
+    def process(*subjects)
+        return "" if subjects.empty?
 
         inputs = []
         

--- a/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -43,7 +43,7 @@ class DataFoodConsortium::Connector::JsonLdSerializer
 
         jsonLd = JSON::LD::API.compact(inputs, @outputContext)
 
-        return JSON.generate(jsonLd)
+        JSON.generate(jsonLd)
     end
 
 end

--- a/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -43,7 +43,7 @@ class DataFoodConsortium::Connector::JsonLdSerializer
         # the DFC's context can be used.
         # See https://github.com/datafoodconsortium/connector-ruby/issues/11.
         subjects.each do |subject|
-            input = { "@context" => "https://www.datafoodconsortium.org" }
+            input = { "@context" => @outputContext }
             input.merge!(subject.serialize(@hashSerializer))
             inputs.push(input)
         end


### PR DESCRIPTION
While the codegen repository is out of date, I'll create my pull requests here.

I like to use the exporter with a cached version of the context to avoid network requests and make the documents stable even if the context changes. The exporter supported this to a degree what was still hard-coding the DFC context URL as well. I'm changing this here and tidy the code a little bit.