### PR TITLE
Preload context to avoid remote loading

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,29 @@
 PATH
   remote: .
   specs:
-    datafoodconsortium-connector (1.0.0.pre.alpha.4)
-      virtual_assembly-semantizer (~> 1.0, >= 1.0.2)
+    datafoodconsortium-connector (1.0.0.pre.alpha.8)
+      virtual_assembly-semantizer (~> 1.0, >= 1.0.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
     htmlentities (4.3.4)
-    json-canonicalization (0.3.1)
-    json-ld (3.2.3)
+    json-canonicalization (0.3.2)
+    json-ld (3.2.5)
       htmlentities (~> 4.3)
-      json-canonicalization (~> 0.3)
+      json-canonicalization (~> 0.3, >= 0.3.2)
       link_header (~> 0.0, >= 0.0.8)
       multi_json (~> 1.15)
-      rack (~> 2.2)
-      rdf (~> 3.2, >= 3.2.9)
+      rack (>= 2.2, < 4)
+      rdf (~> 3.2, >= 3.2.10)
     link_header (0.0.8)
     minitest (5.17.0)
     multi_json (1.15.0)
-    rack (2.2.6.2)
+    rack (3.0.8)
     rake (13.0.6)
-    rdf (3.2.9)
+    rdf (3.2.11)
       link_header (~> 0.0, >= 0.0.8)
-    virtual_assembly-semantizer (1.0.2)
+    virtual_assembly-semantizer (1.0.5)
       json-ld (~> 3.2, >= 3.2.3)
 
 PLATFORMS

--- a/lib/datafoodconsortium/connector/connector.rb
+++ b/lib/datafoodconsortium/connector/connector.rb
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 require 'singleton'
+require 'datafoodconsortium/connector/context'
 require 'datafoodconsortium/connector/json_ld_serializer'
 
 class DataFoodConsortium::Connector::Connector

--- a/lib/datafoodconsortium/connector/context.rb
+++ b/lib/datafoodconsortium/connector/context.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'json/ld'
+
+# Preload the DFC context.
+#
+# Similar to: https://github.com/ruby-rdf/json-ld-preloaded/
+module DataFoodConsortium
+  module Connector
+    class Context < JSON::LD::Context
+      VERSION_1_8 = JSON.parse <<~JSON
+        {
+          "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+          "skos" : "http://www.w3.org/2004/02/skos/core#",
+          "dfc": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_FullModel.owl#",
+          "dc": "http://purl.org/dc/elements/1.1/#",
+          "dfc-b": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_BusinessOntology.owl#",
+          "dfc-p": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_ProductGlossary.owl#",
+          "dfc-t": "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_TechnicalOntology.owl#",
+          "dfc-m": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
+          "dfc-pt": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
+          "dfc-f": "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/facets.rdf#",
+          "ontosec": "http://www.semanticweb.org/ontologies/2008/11/OntologySecurity.owl#",
+          "dfc-p:hasUnit":{ "@type":"@id" },
+          "dfc-b:hasUnit":{ "@type":"@id" },
+          "dfc-b:hasQuantity":{ "@type":"@id" },
+          "dfc-p:hasType":{ "@type":"@id" },
+          "dfc-b:hasType":{ "@type":"@id" },
+          "dfc-b:references":{ "@type":"@id" },
+          "dfc-b:referencedBy":{ "@type":"@id" },
+          "dfc-b:offeres":{ "@type":"@id" },
+          "dfc-b:supplies":{ "@type":"@id" },
+          "dfc-b:defines":{ "@type":"@id" },
+          "dfc-b:affiliates":{ "@type":"@id" },
+          "dfc-b:hasCertification":{ "@type":"@id" },
+          "dfc-b:manages":{ "@type":"@id" },
+          "dfc-b:offeredThrough":{ "@type":"@id" },
+          "dfc-b:hasBrand":{ "@type":"@id" },
+          "dfc-b:hasGeographicalOrigin":{ "@type":"@id" },
+          "dfc-b:hasClaim":{ "@type":"@id" },
+          "dfc-b:hasAllergenDimension":{ "@type":"@id" },
+          "dfc-b:hasNutrientDimension":{ "@type":"@id" },
+          "dfc-b:hasPhysicalDimension":{ "@type":"@id" },
+          "dfc:owner":{ "@type":"@id" },
+          "dfc-t:hostedBy":{ "@type":"@id" },
+          "dfc-t:hasPivot":{ "@type":"@id" },
+          "dfc-t:represent":{ "@type":"@id" }
+        }
+      JSON
+
+      add_preloaded("http://www.datafoodconsortium.org/") { parse(VERSION_1_8) }
+      alias_preloaded(
+        "http://static.datafoodconsortium.org/ontologies/context.json",
+        "http://www.datafoodconsortium.org/"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Loading a local version of the context is recommended for several
reasons.

 * It reduces test run time from 53 seconds to less than a second.
 * It ensures that our hard-coded URIs are in sync with the used context.
 * It guards us against network errors and downtime of the DFC website.
 
The first two commits are just to get the CI environment running as in the previous PR.