### PR TITLE
Export valid empty JSON instead of invalid empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Export valid empty JSON instead of invalid empty string
+
 ## [1.1.0] - 2025-01-14
 
 This version has been generated using:

--- a/lib/datafoodconsortium/connector/connector.rb
+++ b/lib/datafoodconsortium/connector/connector.rb
@@ -35,8 +35,8 @@ class DataFoodConsortium::Connector::Connector
     attr_reader :MEASURES
     attr_reader :PRODUCT_TYPES
 
-    def export(subject, *subjects)
-        return @exporter.process(subject, *subjects)
+    def export(*subjects)
+        @exporter.process(*subjects)
     end
 
     def import(json_string_or_io)

--- a/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -31,8 +31,6 @@ class DataFoodConsortium::Connector::JsonLdSerializer
     end
 
     def process(*subjects)
-        return "" if subjects.empty?
-
         # Insert an input context on each subject so the properties could be prefixed. This way,
         # the DFC's context can be used.
         # See https://github.com/datafoodconsortium/connector-ruby/issues/11.

--- a/spec/connector_spec.rb
+++ b/spec/connector_spec.rb
@@ -36,4 +36,10 @@ RSpec.describe DataFoodConsortium::Connector::Connector do
     expect(result.semanticId).to eq "https://example.net/tomato"
     expect(result.name).to eq "Tomato"
   end
+
+  it "imports valid but empty documents" do
+    json = "{}"
+    result = connector.import(json)
+    expect(result).to eq nil
+  end
 end

--- a/spec/export_spec.rb
+++ b/spec/export_spec.rb
@@ -1,4 +1,11 @@
 RSpec.describe DataFoodConsortium::Connector::Connector do
+  it "exports an empty list" do
+    subjects = []
+    actual = exported_json(*subjects)
+    expected = {"@context"=>"https://www.datafoodconsortium.org"}
+    expect(actual).to eq expected
+  end
+
   it "exports multiple subjects in a graph" do
     a = DataFoodConsortium::Connector::Address.new(
       "https://myplatform.com/a",

--- a/spec/importer_spec.rb
+++ b/spec/importer_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe DataFoodConsortium::Connector::Importer do
     )
   end
 
+  it "imports an empty DFC document" do
+    result = import # nothing
+    expect(result).to eq nil
+  end
+
   it "imports a single object with simple properties" do
     result = import(product)
 


### PR DESCRIPTION
When listing items like enterprises on the API, we may have an empty list. Trying to export an empty list was raising an error on the export method because it was expecting at least one subject. And if you used the exporter directly, it would return an empty string which is not valid JSON. Now we produce:

```json
{"@context": "https://www.datafoodconsortium.org"}
```

While this seems clear to me, I'm not sure that this is a valid case. Does the DFC require every document to contain the Person accessing the data? So should the `export` method have this signature?

```rb
def export(person, *objects)
  ...
end
```

If that's really the case then we should amend the examples in the Readme file. And current implementations don't follow this rule. The Open Food Network catalog contains the person but most other endpoints don't. The Food Data Collaboration (FDC) API for Shopify doesn't include a Person at all.